### PR TITLE
Return correct status codes

### DIFF
--- a/shoal-agent/scripts/shoal-agent
+++ b/shoal-agent/scripts/shoal-agent
@@ -66,11 +66,14 @@ status () {
             if [ $? -eq 0 ]; then
                 PID=`cat $PIDFILE`
                 echo $"$SERVICE is running with PID ${PID}."
+                return 0
             else
                 echo $"$SERVICE has exited unexpectedly."
+                return 1
             fi
         else
             echo "$SERVICE isn't running."
+            return 1
         fi
 }
 


### PR DESCRIPTION

```console
# /etc/init.d/shoal-agent status
shoal_agent has exited unexpectedly.
# echo $?
1
```

is now correct, was returning 0 whatever before.
