### PR TITLE
Install system version if --root specified

### DIFF
--- a/shoal-agent/setup.py
+++ b/shoal-agent/setup.py
@@ -14,7 +14,7 @@ from shoal_agent.__version__ import version
 
 data_files = []
 
-if not os.geteuid() == 0:
+if not os.geteuid() == 0 and '--root' not in sys.argv:
     config_files_dir = expanduser("~/.shoal/")
 else:
     config_files_dir = "/etc/shoal/"


### PR DESCRIPTION
When trying to build the rpm calling setup tools as a non root user the wrong thing happens and userspace version is installed which consequently fails as an RPM.

The patch says that specification --root /tmp/a says install as system installation at that location.

```bash
%{__python} setup.py install -O1 --skip-build --root $RPM_BUILD_ROOT
```

There are probably better ways to do this using --user option or something but this should at least
be backwards compatible.

Steve.