### PR TITLE
Add timeout to verification #87

### DIFF
--- a/shoal-server/shoal_server/utilities.py
+++ b/shoal-server/shoal_server/utilities.py
@@ -282,7 +282,7 @@ def is_available(ip, port):
         testflag = False
         try:
             repo = re.search("cvmfs\/(.+?)(\/|\.)", targeturl).group(1)
-            file = requests.get(targeturl, proxies=proxies)
+            file = requests.get(targeturl, proxies=proxies, timeout=2)
             f = file.content
         except:
             #note that this would catch any RE errors aswell but they are specified in the config and all fit the pattern.


### PR DESCRIPTION
I've added a 2 second timeout to the verification request.
This should allow time for the file to be downloaded even
if it is half the world away. This should make for a more
responsive server on a restart adding the squids back to
human UI much faster. This will also make it so the server
never spends more than 2 seconds on a bad(unverifiable)
squid.