### PR TITLE
remove cvmfs config info for #123

### DIFF
--- a/shoal-client/conf/shoal_client.conf
+++ b/shoal-client/conf/shoal_client.conf
@@ -4,10 +4,6 @@
 
 [general]
 
-# CVMFS HTTP Proxy File
-#
-cvmfs_config = /etc/cvmfs/default.local
-
 # URL of shoal server rest api to find nearest squid.
 #
 #if the shoal server has verification running use the following URL

--- a/shoal-client/shoal-client
+++ b/shoal-client/shoal-client
@@ -17,7 +17,6 @@ from urllib2 import urlopen
 from subprocess import Popen, PIPE
 
 server = config.shoal_server_url
-cvmfs_config = config.cvmfs_config
 default_http_proxy = config.default_squid_proxy
 
 data = None

--- a/shoal-client/shoal_client/config.py
+++ b/shoal-client/shoal_client/config.py
@@ -14,7 +14,6 @@ import logging
 """
 # set default values
 shoal_server_url = 'http://localhost:8080/nearest'
-cvmfs_config = "/etc/cvmfs/default.local"
 default_squid_proxy   = ""
 
 homedir = expanduser('~')
@@ -52,8 +51,6 @@ except:
 # sets defaults to the options in config_file
 if config_file.has_option("general", "shoal_server_url"):
     shoal_server_url = config_file.get("general", "shoal_server_url")
-if config_file.has_option("general", "cvmfs_config"):
-    cvmfs_config = config_file.get("general", "cvmfs_config")
 
 if config_file.has_option("general", "default_squid_proxy"):
     default_squid_proxy = config_file.get("general", "default_squid_proxy")


### PR DESCRIPTION
These config options are no longer used since the client uses `cvmfs_talk proxy set`
