### PR TITLE
Refactor of shoal-client to consistently append default squids. Resolves #127, #125

### DIFF
--- a/shoal-client/shoal-client
+++ b/shoal-client/shoal-client
@@ -131,7 +131,8 @@ try:
     logging.info("Checking Enviroment Variable for default proxy")
     env_proxy = os.environ['HTTP_PROXY']
     logging.info("Enviroment Variable located, adding: %s as default proxy" % env_proxy)
-    env_proxy += ";"
+    if env_proxy != "":
+        env_proxy += ";"
 
 except KeyError as e:
     logging.error("No HTTP_PROXY enviroment variable found")

--- a/shoal-client/shoal-client
+++ b/shoal-client/shoal-client
@@ -138,7 +138,11 @@ except KeyError as e:
 
 ## read server data (if it can be read) into a dictionary called data
 try:
-    f = urlopen(server, timeout = 1)
+    #if there is a bad proxy set we will never reach shoal-server
+    #this goes direct to avoid any bad configuration
+    proxy_handler = urllib2.ProxyHandler({})
+    opener = urllib2.build_opener(proxy_handler)
+    f = opener.open(server, timeout = 1)
     # data = json.loads(f.read())
     data = parseServerData(f.read())
     logging.debug("Got data from %s" % server)

--- a/shoal-client/shoal-client
+++ b/shoal-client/shoal-client
@@ -25,8 +25,8 @@ closest_http_proxy = ''
 env_proxy = ''
 no_shoal_server = False
 
-#logging.basicConfig(filename="/var/log/shoal_client.log", format='%(asctime)s %(message)s')
-logging.basicConfig(filename="/var/log/shoal_client.log", format='%(asctime)s %(message)s', level=logging.DEBUG)
+logging.basicConfig(filename="/var/log/shoal_client.log", format='%(asctime)s %(message)s', level=logging.INFO)
+#logging.basicConfig(filename="/var/log/shoal_client.log", format='%(asctime)s %(message)s', level=logging.DEBUG)
 
 def get_args():
     """

--- a/shoal-client/shoal-client
+++ b/shoal-client/shoal-client
@@ -131,6 +131,7 @@ try:
     logging.info("Checking Enviroment Variable for default proxy")
     env_proxy = os.environ['HTTP_PROXY']
     logging.info("Enviroment Variable located, adding: %s as default proxy" % env_proxy)
+    env_proxy += ";"
 
 except KeyError as e:
     logging.error("No HTTP_PROXY enviroment variable found")

--- a/shoal-client/shoal-client
+++ b/shoal-client/shoal-client
@@ -164,7 +164,7 @@ if not no_shoal_server:
             logging.error("The data returned from '%s' was missing the key: %s. Please ensure the server is running the latest version of Shoal-Server." % (server, e))
             sys.exit(2)
 
-    cvmfs_http_proxy = "\"" + closest_http_proxy + default_http_proxy + env_proxy + "\""
+    cvmfs_http_proxy = "\"" + closest_http_proxy + env_proxy + default_http_proxy + "\""
     logging.debug("Data parsing complete.")
     logging.info("Setting %s as proxy" % cvmfs_http_proxy)
     ## if dump, don't set CVMFS proxies
@@ -195,7 +195,7 @@ if not no_shoal_server:
 else:
 
 
-    cvmfs_http_proxy = "\"" + default_http_proxy + env_proxy + "\""
+    cvmfs_http_proxy = "\"" + env_proxy + default_http_proxy + "\""
     logging.info("Setting %s as proxy" % cvmfs_http_proxy)
     ## if dump, don't set CVMFS proxies
     if dump:

--- a/shoal-client/shoal-client
+++ b/shoal-client/shoal-client
@@ -22,6 +22,7 @@ default_http_proxy = config.default_squid_proxy
 data = None
 dump = False 
 closest_http_proxy = ''
+env_proxy = ''
 no_shoal_server = False
 
 #logging.basicConfig(filename="/var/log/shoal_client.log", format='%(asctime)s %(message)s')
@@ -125,6 +126,15 @@ get_args()
     stored in cvmfs_http_proxy, executes command to set CVMFS proxies if dump is not specified.
 """
 
+## try to load default value from env variable
+try:
+    logging.info("Checking Enviroment Variable for default proxy")
+    env_proxy = os.environ['HTTP_PROXY']
+    logging.info("Enviroment Variable located, adding: %s as default proxy" % env_proxy)
+
+except KeyError as e:
+    logging.error("No HTTP_PROXY enviroment variable found")
+
 ## read server data (if it can be read) into a dictionary called data
 try:
     f = urlopen(server)
@@ -137,6 +147,7 @@ except (urllib2.URLError,ValueError), e:
     # refactoring instead of injecting code here to reuse the proceeding code.
     #checkEnvVariable()
     #checkConfig()
+    logging.error("Unable to reach shoal-server, reverting to defaults")
     no_shoal_server = True
     #sys.exit(1)
 
@@ -145,6 +156,7 @@ if not no_shoal_server:
 
     ## iterate through the data dict and use all hostname and squid_port keys
     ## to create addresses for squids in closest_http_proxy
+    logging.info("Received data from server, processing.")
     for i in range(0, len(data)):
         try:
             closest_http_proxy += 'http://%s:%s;' % (data['%s'%i]['hostname'], data['%s'%i]['squid_port'])
@@ -152,11 +164,12 @@ if not no_shoal_server:
             logging.error("The data returned from '%s' was missing the key: %s. Please ensure the server is running the latest version of Shoal-Server." % (server, e))
             sys.exit(2)
 
-    cvmfs_http_proxy = "\"" + closest_http_proxy + default_http_proxy + "\""
+    cvmfs_http_proxy = "\"" + closest_http_proxy + default_http_proxy + env_proxy + "\""
     logging.debug("Data parsing complete.")
-
+    logging.info("Setting %s as proxy" % cvmfs_http_proxy)
     ## if dump, don't set CVMFS proxies
     if dump:
+        logging.info("Dumping proxy string")
         print cvmfs_http_proxy
     else:
         logging.debug("Executing 'cvmfs_talk proxy set %s'" % cvmfs_http_proxy)
@@ -180,19 +193,28 @@ if not no_shoal_server:
 #First check if there is a value in the env variable
 #Second check if there is a valid default in shoal_client.conf
 else:
-    try:
-        logging.info("Checking Enviroment Variable for default proxy")
-        env_proxy = os.environ['HTTP_PROXY']
-        logging.info("Enviroment Variable located setting: %s as proxy" % env_proxy)
-        '''
-         set proxy here
-        '''
-        sys.exit(1)
-    except KeyError as e:
-        logging.error("No HTTP_PROXY enviroment variable found")
 
-    try:
-        logging.info("Checking client config for default proxy")
-        sys.exit(1)
-    except:
-        sys.exit(1)
+
+    cvmfs_http_proxy = "\"" + default_http_proxy + env_proxy + "\""
+    logging.info("Setting %s as proxy" % cvmfs_http_proxy)
+    ## if dump, don't set CVMFS proxies
+    if dump:
+        logging.info("Dumping proxy string")
+        print cvmfs_http_proxy
+    else:
+        logging.debug("Executing 'cvmfs_talk proxy set %s'" % cvmfs_http_proxy)
+        try:
+            p = Popen(["cvmfs_talk", "proxy", "set", cvmfs_http_proxy], stdout=PIPE, stderr=PIPE)
+            output, errors = p.communicate()
+            if errors:
+                logging.error(errors)
+            if output:
+                logging.debug(output)
+            if p.returncode:
+                logging.error("WARNING: CVMFS proxies may not have been set correctly for all repos")
+                sys.exit(p.returncode)
+            else:
+                logging.info("CVMFS proxies set to %s" % cvmfs_http_proxy)
+        except OSError as e:
+            logging.error("Could not execute cvmfs_talk: %s" % e.strerror)
+            sys.exit(e.errno)

--- a/shoal-client/shoal-client
+++ b/shoal-client/shoal-client
@@ -138,7 +138,7 @@ except KeyError as e:
 
 ## read server data (if it can be read) into a dictionary called data
 try:
-    f = urlopen(server)
+    f = urlopen(server, timeout = 1)
     # data = json.loads(f.read())
     data = parseServerData(f.read())
     logging.debug("Got data from %s" % server)

--- a/shoal-client/shoal-client
+++ b/shoal-client/shoal-client
@@ -23,9 +23,10 @@ default_http_proxy = config.default_squid_proxy
 data = None
 dump = False 
 closest_http_proxy = ''
+no_shoal_server = False
 
-logging.basicConfig(filename="/var/log/shoal_client.log", format='%(asctime)s %(message)s')
-#logging.basicConfig(filename="/var/log/shoal_client.log", format='%(asctime)s %(message)s', level=logging.DEBUG)
+#logging.basicConfig(filename="/var/log/shoal_client.log", format='%(asctime)s %(message)s')
+logging.basicConfig(filename="/var/log/shoal_client.log", format='%(asctime)s %(message)s', level=logging.DEBUG)
 
 def get_args():
     """
@@ -130,41 +131,69 @@ try:
     f = urlopen(server)
     # data = json.loads(f.read())
     data = parseServerData(f.read())
+    logging.debug("Got data from %s" % server)
 except (urllib2.URLError,ValueError), e:
     logging.error("Unable to open URL %s : %s" % (server, e))
-    sys.exit(1)
-logging.debug("Got data from %s" % server)
+    # This is where the client now exits if it can't reach shoal, might be worth 
+    # refactoring instead of injecting code here to reuse the proceeding code.
+    #checkEnvVariable()
+    #checkConfig()
+    no_shoal_server = True
+    #sys.exit(1)
 
-## iterate through the data dict and use all hostname and squid_port keys
-## to create addresses for squids in closest_http_proxy
-for i in range(0, len(data)):
-    try:
-        closest_http_proxy += 'http://%s:%s;' % (data['%s'%i]['hostname'], data['%s'%i]['squid_port'])
-    except KeyError, e:
-        logging.error("The data returned from '%s' was missing the key: %s. Please ensure the server is running the latest version of Shoal-Server." % (server, e))
-        sys.exit(2)
+# If the shoal_server was reachable
+if not no_shoal_server:
 
-cvmfs_http_proxy = "\"" + closest_http_proxy + default_http_proxy + "\""
-logging.debug("Data parsing complete.")
+    ## iterate through the data dict and use all hostname and squid_port keys
+    ## to create addresses for squids in closest_http_proxy
+    for i in range(0, len(data)):
+        try:
+            closest_http_proxy += 'http://%s:%s;' % (data['%s'%i]['hostname'], data['%s'%i]['squid_port'])
+        except KeyError, e:
+            logging.error("The data returned from '%s' was missing the key: %s. Please ensure the server is running the latest version of Shoal-Server." % (server, e))
+            sys.exit(2)
 
-## if dump, don't set CVMFS proxies
-if dump:
-    print cvmfs_http_proxy
+    cvmfs_http_proxy = "\"" + closest_http_proxy + default_http_proxy + "\""
+    logging.debug("Data parsing complete.")
+
+    ## if dump, don't set CVMFS proxies
+    if dump:
+        print cvmfs_http_proxy
+    else:
+        logging.debug("Executing 'cvmfs_talk proxy set %s'" % cvmfs_http_proxy)
+        try:
+            p = Popen(["cvmfs_talk", "proxy", "set", cvmfs_http_proxy], stdout=PIPE, stderr=PIPE)
+            output, errors = p.communicate()
+            if errors:
+                logging.error(errors)
+            if output:
+                logging.debug(output)
+            if p.returncode:
+                logging.error("WARNING: CVMFS proxies may not have been set correctly for all repos")
+                sys.exit(p.returncode)
+            else:
+                logging.info("CVMFS proxies set to %s" % cvmfs_http_proxy)
+        except OSError as e:
+            logging.error("Could not execute cvmfs_talk: %s" % e.strerror)
+            sys.exit(e.errno)
+
+#if we get here the client as unable to connect to the shoal_server
+#First check if there is a value in the env variable
+#Second check if there is a valid default in shoal_client.conf
 else:
-    logging.debug("Executing 'cvmfs_talk proxy set %s'" % cvmfs_http_proxy)
     try:
-        p = Popen(["cvmfs_talk", "proxy", "set", cvmfs_http_proxy], stdout=PIPE, stderr=PIPE)
-        output, errors = p.communicate()
-        if errors:
-            logging.error(errors)
-        if output:
-            logging.debug(output)
-        if p.returncode:
-            logging.error("WARNING: CVMFS proxies may not have been set correctly for all repos")
-            sys.exit(p.returncode)
-        else:
-            logging.info("CVMFS proxies set to %s" % cvmfs_http_proxy)
-    except OSError as e:
-        logging.error("Could not execute cvmfs_talk: %s" % e.strerror)
-        sys.exit(e.errno)
+        logging.info("Checking Enviroment Variable for default proxy")
+        env_proxy = os.environ['HTTP_PROXY']
+        logging.info("Enviroment Variable located setting: %s as proxy" % env_proxy)
+        '''
+         set proxy here
+        '''
+        sys.exit(1)
+    except KeyError as e:
+        logging.error("No HTTP_PROXY enviroment variable found")
 
+    try:
+        logging.info("Checking client config for default proxy")
+        sys.exit(1)
+    except:
+        sys.exit(1)

--- a/shoal-client/shoal_client/__version__.py
+++ b/shoal-client/shoal_client/__version__.py
@@ -1,1 +1,1 @@
-version = "0.6.1"
+version = "0.6.3"

--- a/shoal-server/README.md
+++ b/shoal-server/README.md
@@ -11,11 +11,8 @@ Clients can use the Shoal Server RESTful API to retrieve a list of nearest squid
 - To retrieve a variable size of nearest verified squids you can use `http://localhost/nearestverified/<# of squids>`. For example to retrieve the closest 20 squid servers you can use:
  - `http://localhost/nearestverified/20`
 
-- To get a list of the default 5 nearest squids use:
- - `http://localhost/nearest`
-- To retrieve a variable size of nearest squids you can use `http://localhost/nearest/<# of squids>`. For example to retrieve the closest 20 squid servers you can use:
- - `http://localhost/nearest/20`
- 
+- The extension 'nearest' returns the same as 'nearestverified', specifically `http://localhost/nearestverified/20` is the same as `http://localhost/nearest/20`.  Previously these did different things, but their functionality has now been merged. Both are kept to maintain compatibility with previous versions of Shoal Client.
+
 - To get a list of all squids stored in shoal use:
   - `http://localhost/all`
  


### PR DESCRIPTION
Changes to shoal-client:
- Now always checks the environment variable for a default value and appends it and the default from the config file to the end of the proxy list.
- Instead of exiting when the shoal-server is unreachable it checks for the 2 possible default values and appends them to the proxy variable and sets them with cvmfs_talk
- Added additional info logging in regards to the proxys being set

Should resolve #127 and #125 
Could also potentially resolve #124 