### PR TITLE
fix removal of FRONTIER_SERVER in case of shoal problems

### DIFF
--- a/shoal-client/shoal-client
+++ b/shoal-client/shoal-client
@@ -185,6 +185,7 @@ if not no_shoal_server:
                     "The data returned from '%s' was missing the key: %s. "
                     "Please ensure the server is running the latest version "
                     "of Shoal-Server." % (server, e))
+                print os.getenv("FRONTIER_SERVER", "")
                 sys.exit(2)
 
     else:


### PR DESCRIPTION
more fixes are coming, but this is for the current problem at hand. Could you create a new version ? New VMs then could pick this fix up, as they currently do a pip install a  startup.