### PR TITLE
Make shoal-agent work with python2 or python3

### DIFF
--- a/shoal-agent/shoal-agent
+++ b/shoal-agent/shoal-agent
@@ -5,6 +5,7 @@
 # You may distribute under the terms of either the GNU General Public
 # License or the Apache v2 License.
 
+from __future__ import print_function
 
 import sys
 import json
@@ -110,7 +111,7 @@ def main():
     try:
         logging.basicConfig(level=config.logging_level, format=LOG_FORMAT, filename=config.log_file)
     except IOError as exc:
-        print "Could not set logging file. Please check config file.", exc
+        print("Could not set logging file. Please check config file.", exc)
         sys.exit(1)
 
     data = {
@@ -129,14 +130,14 @@ def main():
 
     #set the data to the first valid IP address
     try:
-        data['private_ip'] = private_ip.values()[0]
+        data['private_ip'] = list(private_ip.values())[0]
     except IndexError:
         pass
 
     if public_ip:
         try:
-            data['public_ip'] = public_ip.values()[0]
-            data['hostname'] = socket.gethostbyaddr(public_ip.values()[0])[0]
+            data['public_ip'] = list(public_ip.values())[0]
+            data['hostname'] = socket.gethostbyaddr(list(public_ip.values())[0])[0]
         except IndexError:
             pass
     elif external_ip:
@@ -162,9 +163,9 @@ def main():
     if config.interface:
         interface = config.interface
     elif public_ip:
-        interface = public_ip.keys()[0]
+        interface = list(public_ip.keys())[0]
     elif private_ip:
-        interface = private_ip.keys()[0]
+        interface = list(private_ip.keys())[0]
     else:
         logging.error("Unable to automatically detect interface to monitor, please "
                       "set the interface to monitor in configuration file.")
@@ -189,10 +190,13 @@ def main():
                 logging.error("Could not connect to AMQP Server. Attempting to connect in {0}s...".format(INTERVAL))
                 logging.error(exc)
             time.sleep(INTERVAL)
-        except KeyboardInterrupt, KeyError:
+        except KeyboardInterrupt:
+            logging.info("shoal-agent exiting")
+            sys.exit()
+        except KeyError:
             logging.info("shoal-agent exiting")
             sys.exit()
 
 if __name__ == '__main__':
-    print "starting shoal-agent"
+    print("starting shoal-agent")
     main()

--- a/shoal-agent/shoal_agent/config.py
+++ b/shoal-agent/shoal_agent/config.py
@@ -1,7 +1,12 @@
-from os.path import exists, join, expanduser, abspath
+from __future__ import print_function
+
+from os.path import exists, join, expanduser, abspath, dirname
 import sys
-import ConfigParser
 import logging
+try:
+    import configparser
+except ImportError:  # python < 3
+    import ConfigParser as configparser
 
 # Shoal Options Module
 
@@ -44,34 +49,40 @@ max_load = 122000
 homedir = expanduser('~')
 
 # find config file by checking the directory of the calling script and sets path
-if  exists(abspath(sys.path[0]+"/shoal_agent.conf")):
+if exists(abspath(sys.path[0]+"/shoal_agent.conf")):
     path = abspath(sys.path[0]+"/shoal_agent.conf")
+elif exists(abspath(dirname(sys.path[0])+"/shoal_agent.conf")):
+    path = abspath(dirname(sys.path[0])+"/shoal_agent.conf")
 elif exists("/etc/shoal/shoal_agent.conf"):
     path = "/etc/shoal/shoal_agent.conf"
 elif exists(abspath(homedir + "/.shoal/shoal_agent.conf")):
     path = abspath(homedir + "/.shoal/shoal_agent.conf")
 else:
-    print >> sys.stderr, "Configuration file problem: There doesn't " \
-                          "seem to be a configuration file. " \
-                          "You can specify one in /etc/shoal/shoal_agent.conf"
+    print( "Configuration file problem: There doesn't " \
+              "seem to be a configuration file. " \
+              "You can specify one in /etc/shoal/shoal_agent.conf",
+           file=sys.stderr)
     sys.exit(1)
 
 # Read config file from the given path above
-config_file = ConfigParser.ConfigParser()
+config_file = configparser.ConfigParser()
 try:
     config_file.read(path)
 except IOError:
-    print >> sys.stderr, "Configuration file problem: There was a " \
-                          "problem reading %s. Check that it is readable," \
-                          "and that it exists. " % path
+    print("Configuration file problem: There was a " \
+          "problem reading %s. Check that it is readable," \
+          "and that it exists. " % path,
+          file=sys.stderr)
     raise
-except ConfigParser.ParsingError:
-    print >> sys.stderr, "Configuration file problem: Couldn't " \
-                         "parse your file. Check for spaces before or after variables."
+except configparser.ParsingError:
+    print("Configuration file problem: Couldn't " \
+          "parse your file. Check for spaces before or after variables.",
+          file=sys.stderr)
+
     raise
 except:
-    print "Configuration file problem: There is something wrong with " \
-          "your config file."
+    print("Configuration file problem: There is something wrong with " \
+          "your config file.")
     raise
 
 # sets defaults to the options in the config file
@@ -82,8 +93,8 @@ if config_file.has_option("rabbitmq", "amqp_port"):
     try:
         amqp_port = config_file.getint("rabbitmq", "amqp_port")
     except ValueError:
-        print "Configuration file problem: amqp_port must be an " \
-              "integer value."
+        print("Configuration file problem: amqp_port must be an " \
+              "integer value.")
         sys.exit(1)
 
 if config_file.has_option("rabbitmq", "use_ssl") and config_file.getboolean("rabbitmq", "use_ssl"):
@@ -93,8 +104,8 @@ if config_file.has_option("rabbitmq", "use_ssl") and config_file.getboolean("rab
         amqp_client_cert = abspath(config_file.get("rabbitmq", "amqp_client_cert"))
         amqp_client_key  = abspath(config_file.get("rabbitmq", "amqp_client_key"))
     except Exception as e:
-        print "Configuration file problem: could not load SSL certs"
-        print e
+        print("Configuration file problem: could not load SSL certs")
+        print(e)
         sys.exit(1)
 
 if config_file.has_option("rabbitmq", "amqp_virtual_host"):
@@ -107,8 +118,8 @@ if config_file.has_option("general", "interval"):
     try:
         interval = config_file.getint("general", "interval")
     except ValueError:
-        print "Configuration file problem: interval must be an " \
-              "integer value."
+        print("Configuration file problem: interval must be an " \
+              "integer value.")
         sys.exit(1)
 
 if config_file.has_option("general", "cloud"):
@@ -129,15 +140,15 @@ if config_file.has_option("logging", "logging_level"):
     try:
         logging_level = logLevels[temp]
     except KeyError:
-        print "Configuration file problem: Invalid logging level"
+        print("Configuration file problem: Invalid logging level")
         sys.exit(1)
 
 if config_file.has_option("general", "squid_port"):
     try:
         squid_port = config_file.getint("general", "squid_port")
     except ValueError:
-        print "Configuration file problem: squid_port must be an " \
-              "integer value."
+        print("Configuration file problem: squid_port must be an " \
+              "integer value.")
         sys.exit(1)
  
 if config_file.has_option("general", "external_ip"):


### PR DESCRIPTION
This PR ports shoal-agent to python3 while still allowing it to work with python2.  I needed to use python3 in order to make a seamless frontier-squid rpm package that works el6 through el8.

After this is merged and you make a new tagged release, please use a tag starting with "agent-" rather than "shoal-agent", because when you download source code from github it puts the files in a directory based on repositoryname-tagname.  Currently the rpm build needs to cd into the ugly looking directory of "shoal-shoal-agent-0.9.5".