### PR TITLE
Merge client-python3 to master for V1.0.1

### DIFF
--- a/shoal-client/README.md
+++ b/shoal-client/README.md
@@ -1,5 +1,5 @@
 # Shoal Client README
-# Version: v1.0.0
+# Version: v1.0.1
 
 shoal-client will configure cvmfs to use the closest squid server to you by contacting the shoal server
 and using cvmfs-talk to update the active proxy configuration.

--- a/shoal-client/setup.py
+++ b/shoal-client/setup.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 from os.path import isfile, join
 import sys
@@ -9,7 +10,7 @@ except:
     try:
         from distutils.core import setup
     except:
-        print("Couldn't use either setuptools or distutils. Install one of those.")
+        print("Couldn't use either setuptools or distutils. Install one of those.", file=sys.stderr)
         sys.exit(1)
 
 from shoal_client.__version__ import version
@@ -18,7 +19,7 @@ try:
     with io.open("README.md", "r", encoding="utf-8") as fh:
         long_description = fh.read()
 except:
-    print("Couldn't read description from the README.md")
+    print("Couldn't read description from the README.md", file=sys.stderr)
     long_description = ''
 
 setup(name='shoal-client',

--- a/shoal-client/shoal-client
+++ b/shoal-client/shoal-client
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python
 """
     Very simple client script used to get nearest squid server using the RESTful API.
 """

--- a/shoal-client/shoal_client/__version__.py
+++ b/shoal-client/shoal_client/__version__.py
@@ -1,1 +1,1 @@
-version = "1.0.0"
+version = "1.0.1"

--- a/shoal-client/shoal_client/config.py
+++ b/shoal-client/shoal_client/config.py
@@ -42,7 +42,7 @@ try:
                     if proxy not in default_squid_proxy: 
                         default_squid_proxy = proxy + ';' + default_squid_proxy 
 except:
-    print("No default cmfs http proxy found")
+    print("No default cvmfs http proxy found", file=sys.stderr)
 
 homedir = expanduser('~')
 # find config file by checking the directory of the calling script and sets path
@@ -73,7 +73,7 @@ except configparser.ParsingError:
     raise
 except:
     print("Configuration file problem: There is something wrong with " \
-          "your config file.")
+          "your config file.", file=sys.stderr)
     raise
 
 # sets defaults to the options in config_file
@@ -84,5 +84,5 @@ if config_file.has_option("general", "default_squid_proxy"):
     default_squid_proxy = config_file.get("general", "default_squid_proxy")
 else:
     print("No default settings found in the config file, will use DIRECT as default. " \
-          "Please check configuration file:", path)
+          "Please check configuration file: %s" % path, file=sys.stderr)
 

--- a/shoal-client/specs/shoal-client-python3.spec
+++ b/shoal-client/specs/shoal-client-python3.spec
@@ -1,6 +1,6 @@
 %define name shoal-client
-%define version 1.0.0
-%define unmangled_version 1.0.0
+%define version 1.0.1
+%define unmangled_version 1.0.1
 %define release 1
 
 Summary: A squid cache publishing and advertising tool designed to work in fast changing environments

--- a/shoal-client/specs/shoal-client.spec
+++ b/shoal-client/specs/shoal-client.spec
@@ -1,6 +1,6 @@
 %define name shoal-client
-%define version 1.0.0
-%define unmangled_version 1.0.0
+%define version 1.0.1
+%define unmangled_version 1.0.1
 %define release 1
 
 Summary: A squid cache publishing and advertising tool designed to work in fast changing environments


### PR DESCRIPTION
- Update the print statement to std err
- Update the first line in shoal-client from '#!/usr/bin/python2' to '#!/usr/bin/env python', so in the case if run the shoal-client file "./shoal-client", the interpreter used is the first one on the environment's $PATH. This has no impact for the pip package
- Updated the version to V1.0.1 for pip/rpm