### PR TITLE
updated shoal-agent spec file to work with the latest code

### DIFF
--- a/shoal-agent/specs/shoal-agent-python3.spec
+++ b/shoal-agent/specs/shoal-agent-python3.spec
@@ -12,8 +12,9 @@ License: 'GPL3' or 'Apache 2'
 Group: Development/Libraries
 BuildArch: noarch
 Vendor: UVic HEPRC <rsobie@uvic.ca>
-Requires: python-netifaces >= 0.5 
-Requires: python-pika >= 0.9.5
+BuildRequires: python3-devel
+Requires: python3 >= 3.2
+Requires: python36-netifaces python36-requests python36-pika
 %if 0%{?el6}
 %else
 Requires(post): systemd
@@ -39,13 +40,13 @@ nearest squid proxy.
 %setup -n %{name}-%{unmangled_version}
 
 %build
-python setup.py build
+python3 setup.py build
 
 %install
-python setup.py install --single-version-externally-managed -O1 --root=$RPM_BUILD_ROOT
+python3 setup.py install --single-version-externally-managed -O1 --root=$RPM_BUILD_ROOT
 sudo groupadd shoal
 sudo useradd shoal -g shoal
-sudo python -m pip install pystun
+sudo python3 -m pip install pystun3
 mkdir -p $RPM_BUILD_ROOT/etc/{shoal,init.d,logrotate.d}
 mkdir -p $RPM_BUILD_ROOT/var/log
 mv $RPM_BUILD_ROOT/usr/share/shoal-agent/shoal_agent.conf $RPM_BUILD_ROOT/etc/shoal/shoal_agent.conf
@@ -59,7 +60,7 @@ mkdir -p $RPM_BUILD_ROOT/%{_unitdir}
 mv $RPM_BUILD_ROOT/usr/share/shoal-agent/shoal-agent.service $RPM_BUILD_ROOT/%{_unitdir}/shoal-agent.service
 rm $RPM_BUILD_ROOT/usr/share/shoal-agent/shoal-agent.init
 %endif
-rm -rf $RPM_BUILD_ROOT/%{python_sitelib}/shoal_agent-%{unmangled_version}-py%{python_version}.egg-info
+rm -rf $RPM_BUILD_ROOT/%{python3_sitelib}/shoal_agent-%{unmangled_version}-py%{python3_version}.egg-info
 touch $RPM_BUILD_ROOT/var/log/shoal_agent.log
 
 %post
@@ -80,8 +81,8 @@ touch $RPM_BUILD_ROOT/var/log/shoal_agent.log
 %systemd_postun_with_restart shoal-agent.service
 %endif
 
-%files 
-%{python_sitelib}/shoal_agent
+%files
+%{python3_sitelib}/shoal_agent
 %{_bindir}/shoal-agent
 %attr(-,shoal,shoal) /var/log/shoal_agent.log
 %if 0%{?el6}
@@ -92,5 +93,6 @@ touch $RPM_BUILD_ROOT/var/log/shoal_agent.log
 %config(noreplace) /etc/shoal/shoal_agent.conf
 %config(noreplace) /etc/logrotate.d/shoal-agent
 %config(noreplace) /usr/bin/shoal-agent-installation.sh
+
 
 

--- a/shoal-agent/specs/shoal-agent-python3.spec
+++ b/shoal-agent/specs/shoal-agent-python3.spec
@@ -2,6 +2,8 @@
 %define version 1.0.0
 %define unmangled_version 1.0.0
 %define release 1
+%define group_shoal_num %(grep -c "^shoal" /etc/group)
+%define user_shoal_num %(grep -c "^shoal" /etc/passwd)
 
 Summary: A squid cache publishing and advertising tool designed to work in fast changing environments
 Name: %{name}
@@ -44,8 +46,12 @@ python3 setup.py build
 
 %install
 python3 setup.py install --single-version-externally-managed -O1 --root=$RPM_BUILD_ROOT
+%if %{group_shoal_num} == 0 
 sudo groupadd shoal
+%endif
+%if %{user_shoal_num} == 0
 sudo useradd shoal -g shoal
+%endif
 sudo python3 -m pip install pystun3
 mkdir -p $RPM_BUILD_ROOT/etc/{shoal,init.d,logrotate.d}
 mkdir -p $RPM_BUILD_ROOT/var/log

--- a/shoal-agent/specs/shoal-agent.spec
+++ b/shoal-agent/specs/shoal-agent.spec
@@ -2,6 +2,8 @@
 %define version 1.0.0
 %define unmangled_version 1.0.0
 %define release 1
+%define group_shoal_num %(grep -c "^shoal" /etc/group)
+%define user_shoal_num %(grep -c "^shoal" /etc/passwd)
 
 Summary: A squid cache publishing and advertising tool designed to work in fast changing environments
 Name: %{name}
@@ -43,8 +45,12 @@ python setup.py build
 
 %install
 python setup.py install --single-version-externally-managed -O1 --root=$RPM_BUILD_ROOT
+%if %{group_shoal_num} == 0
 sudo groupadd shoal
+%endif
+%if %{user_shoal_num} == 0
 sudo useradd shoal -g shoal
+%endif
 sudo python -m pip install pystun
 mkdir -p $RPM_BUILD_ROOT/etc/{shoal,init.d,logrotate.d}
 mkdir -p $RPM_BUILD_ROOT/var/log


### PR DESCRIPTION
- added steps for add/ user/group shoal, but this will raise an error if user/group already exists, wondering if we could check if before adding them
- removed steps related to the previous shoal-agent.sysconfig file
- includes the new shoal-agent-installation fil, otherwise will raise the unpacked file error
- change the onwer of shoal_agent.log file to shoal
- install python module pystun through pip command, as didn't find one could be installed through yum
- create another spec file for python3