### PR TITLE
Allow shoal-agent admin email messages to be disabled

### DIFF
--- a/shoal-agent/conf/shoal_agent.conf
+++ b/shoal-agent/conf/shoal_agent.conf
@@ -19,7 +19,9 @@ interval=30
 # The default value is 122000         
 #max_load=122000
 
-# this is the admin email address used to receive notifications
+# To receive email notifications, set enable_email=True
+#enable_email=False
+#
 # The default admin email address is 'root@localhost'
 #admin_email=root@localhost
 

--- a/shoal-agent/conf/shoal_agent.conf
+++ b/shoal-agent/conf/shoal_agent.conf
@@ -21,7 +21,8 @@ interval=30
 
 # To receive email notifications, set enable_email=True
 #enable_email=False
-#
+
+# this is the admin email address used to receive notifications
 # The default admin email address is 'root@localhost'
 #admin_email=root@localhost
 

--- a/shoal-agent/shoal-agent
+++ b/shoal-agent/shoal-agent
@@ -194,6 +194,8 @@ def functionalTest(ip, port):
     return True
 
 def sendEmail():
+    if not enable_email:
+        return
     try:
         msg = EmailMessage()
         msg.set_content(config.email_content)

--- a/shoal-agent/shoal-agent
+++ b/shoal-agent/shoal-agent
@@ -194,6 +194,7 @@ def functionalTest(ip, port):
     return True
 
 def sendEmail():
+    enable_email = config.enable_email
     if not enable_email:
         return
     try:

--- a/shoal-agent/shoal_agent/config.py
+++ b/shoal-agent/shoal_agent/config.py
@@ -50,6 +50,7 @@ load_factor = 0.9
 
 sender_email = 'root@localhost'
 receiver_email = 'root@localhost'
+enable_email  = False
 email_subject = 'Shoal Agent Notification'
 email_content = 'Hello, there is no available squid running on the agent, please review the squid status. Trying to find a squid process automatically will be retried in 30 min. Thanks!'
 last_sent_email = '/var/tmp/last_sent_email'
@@ -208,4 +209,7 @@ if config_file.has_option("general", "max_load"):
 
 if config_file.has_option("general", "admin_email"):
     receiver_email = config_file.get("general", "admin_email")
+
+if config_file.has_option("general", "enable_email"):
+    enable_email = config_file.get("general", "enable_email")
 


### PR DESCRIPTION
When `shoal-agent` can't find a cache server, an email message is sent to the admin email address. For some users, these emails are unnecessary and unwanted. This PR adds a configuration option so these emails can be disabled. Prior to this PR, `shoal-agent` always sent these emails, and this behavior is preserved as the default by this PR.

This PR was tested on a system that was not running Squid. Tests verified that an email was generated by default and could be disabled by explicitly setting the new `enable_email` configuration option to False.